### PR TITLE
Spotify utility update

### DIFF
--- a/LIBRARIES/spotify_utils.py
+++ b/LIBRARIES/spotify_utils.py
@@ -33,7 +33,7 @@ def spotify_open():
 	while (time() - sTime) <= 5:
 		try:
 			win32gui.EnumWindows(open_Hloop, None)
-		except:
+		except EndIteration:
 			break
 
 def spotify_close():
@@ -52,7 +52,7 @@ def spotify_play():
 def open_Hloop(hwnd, arg):
 	if win32gui.GetWindowText(hwnd).startswith("Spotify") and win32gui.GetClassName(hwnd) == "Chrome_WidgetWin_0":
 		win32gui.PostMessage(hwnd, WM_SYSCOMMAND, SC_NEXTWINDOW, 0)
-		return False
+		raise EndIteration
 
 def play_Hloop(hwnd, args):
 	if (win32gui.GetWindowText(hwnd).startswith("Spotify") or win32gui.GetWindowText(hwnd).endswith(args[1])) and win32gui.GetClassName(hwnd) == "Chrome_WidgetWin_0":

--- a/LIBRARIES/spotify_utils.py
+++ b/LIBRARIES/spotify_utils.py
@@ -3,6 +3,7 @@
 
 # BUILT-IN MODULES
 from subprocess import run
+from time import time
 import os
 
 # DEPENDENCIES (pywin32)
@@ -36,12 +37,12 @@ else:
 # CLIENT UTILITY FUNCTIONS
 def spotify_open():
 	run([path])
-	while True:
+	sTime = time()
+	while (time() - sTime) <= 5:
 		try:
 			win32gui.EnumWindows(open_Hloop, None)
 		except:
 			break
-
 
 def spotify_close():
 	os.system("taskkill /f /im spotify.exe") # it might print output to console. tell me if u want it removed :D
@@ -49,16 +50,15 @@ def spotify_close():
 def spotify_play():
 	try:
 		win32gui.EnumWindows(play_Hloop, [VK_SPACE, current_playing_song()])
-		raise RuntimeError("Failed to play/pause")
-	except:
-		pass
+	except EndIteration:
+		return
+	raise RuntimeError("Failed to play/pause")
 
 
 
 def open_Hloop(hwnd, arg):
 	if win32gui.GetWindowText(hwnd).startswith("Spotify") and win32gui.GetClassName(hwnd) == "Chrome_WidgetWin_0":
-		win32gui.ShowWindow(hwnd, SW_NORMAL)
-		win32gui.ShowWindow(hwnd, SW_HIDE)
+		win32gui.PostMessage(hwnd, WM_SYSCOMMAND, SC_NEXTWINDOW, 0)
 		return False
 
 def play_Hloop(hwnd, args):
@@ -75,9 +75,12 @@ def play_Hloop(hwnd, args):
 		win32gui.PostMessage(hwnd, WM_ACTIVATE, WA_INACTIVE, 0)
 
 		if wMin:
-			win32gui.ShowWindow(hwnd, SW_HIDE)
+			win32gui.PostMessage(hwnd, WM_SYSCOMMAND, SC_MINIMIZE, 0)
 
-		return False
+		raise EndIteration
+
+class EndIteration(Exception):
+	pass
 
 
 # TO TEST THE MODULE (feel free to just run the script for testing)

--- a/LIBRARIES/spotify_utils.py
+++ b/LIBRARIES/spotify_utils.py
@@ -7,18 +7,10 @@ from time import time
 import os
 
 # DEPENDENCIES (pywin32)
-# Not sure but it might raise a missing DLL error
 from win32 import win32gui
 from win32.lib.win32con import *
 from spotify_api import current_playing_song
 
-# use this instead:
-#
-# from spotify_utils import *
-#
-# to leave other variables undefined in the main and well, for convenience
-# it might need to use this one if it raises ImportError(Location Unknown):
-#
 # from LIBRARIES.spotify_utils import *
 __all__ = ["spotify_open", "spotify_close", "spotify_play"] 
 
@@ -30,7 +22,7 @@ if os.path.exists(os.environ['appdata'] + "\\Spotify\\Spotify.exe"):
 elif os.path.exists(os.environ['localappdata'] + "\\Microsoft\\WindowsApps\\Spotify.exe"):
 	path += os.environ['localappdata'] + "\\Microsoft\\WindowsApps\\Spotify.exe"
 else:
-	raise ImportError("Spotify not Found.") # we can ask for install location from user and make a REFERENCES txt file for it
+	raise ImportError("Spotify not Found.")
 
 
 
@@ -45,7 +37,7 @@ def spotify_open():
 			break
 
 def spotify_close():
-	os.system("taskkill /f /im spotify.exe") # it might print output to console. tell me if u want it removed :D
+	os.system("taskkill /f /im spotify.exe")
 
 def spotify_play():
 	try:
@@ -56,6 +48,7 @@ def spotify_play():
 
 
 
+# EnumWindows FUNCTIONS
 def open_Hloop(hwnd, arg):
 	if win32gui.GetWindowText(hwnd).startswith("Spotify") and win32gui.GetClassName(hwnd) == "Chrome_WidgetWin_0":
 		win32gui.PostMessage(hwnd, WM_SYSCOMMAND, SC_NEXTWINDOW, 0)
@@ -79,11 +72,12 @@ def play_Hloop(hwnd, args):
 
 		raise EndIteration
 
+# CUSTOM EXCEPTION
 class EndIteration(Exception):
 	pass
 
 
-# TO TEST THE MODULE (feel free to just run the script for testing)
+# DEBUGGER
 if __name__ == '__main__':
 	input("Start Spotify?")
 	spotify_open()


### PR DESCRIPTION
### Changes

**spotify_open:**
- Added 5 secs timeout
- Should now automatically move client below the foreground application (or all depends)

**spotify_play:**
- When minimized, it should now properly minimize and not be moved to the system tray

(For both functions: added custom exception for ending the iteration to catch other exceptions)

**Updated Comments**